### PR TITLE
File naming optimized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 *.png
 .vscode/
 myclass/EventControl.*
-data/
+**/data
 tools/tutorial
 .DS_Store

--- a/cpp/reco/include/TBEvent.hh
+++ b/cpp/reco/include/TBEvent.hh
@@ -83,7 +83,7 @@ public :
    TBranch        *b_hit_isMasked;   //!
    TBranch        *b_hit_isCommissioned;   //!
 
-   TBEvent(TString filein_s, TString fileout_s);
+   TBEvent(TString input_path, TString name);
    TBEvent(TList *f=0);
    virtual ~TBEvent();
    virtual Int_t    Cut(Long64_t entry);
@@ -108,14 +108,15 @@ public :
 
 #ifdef TBEvent_cxx
 
-TBEvent::TBEvent(TString filein_s,TString fileout_s) : fChain(0) 
+TBEvent::TBEvent(TString input_path,TString name) : fChain(0) 
 {
+   TString filein_s = input_path + name + "_build.root";
    TFile *f = new TFile(filein_s);
    TTree *tree = (TTree*)f->Get("ecal");
    //  tree->Print();
    Init(tree);
    // OutFile = new TFile(fileout_s,"RECREATE");
-   OutFileName = fileout_s;
+   OutFileName = name;
 }
 
 TBEvent::TBEvent(TList *f) : fChain(0) 

--- a/cpp/reco/run.cc
+++ b/cpp/reco/run.cc
@@ -4,21 +4,13 @@
 
 #include "src/TBEvent.cc"
 
-void run(int set_ene = 10, string particle = "e"){
+void run(int energy = 10, string particle = "e-"){
 
+/*
 	// TString name = particle + TString(to_string(set_ene));
-	string name = particle + "." + to_string(set_ene);
+	string name = particle + "_" + to_string(set_ene);
 	cout << name << endl;
 
-	std::map<std::string, std::string> run_list {
-		{"e.10", "320"},
-		{"e.20", "378"},
-		{"e.40", "375"},
-		{"e.60", "372"},
-		{"e.80", "367"},
-		{"e.100", "365"},
-		{"e.150", "355"},
-	};
 
 	TString filein = "default";
 	string fileinpath = "../../data/reco/raw_siwecal_90";
@@ -27,11 +19,24 @@ void run(int set_ene = 10, string particle = "e"){
 	TString fileout = "default";
 	string fileoutpath = "rootfiles/";
 	fileout = fileoutpath + "run_90" + run_list[name] + "." + name;
+*/
 
-	cout << "Input: " << filein << endl; 
-	cout << "Output: " << fileout << "*" << endl; 
+	std::map<int, std::string> run_list {
+		{10, "90320"},
+		{20, "90378"},
+		{40, "90375"},
+		{60, "90372"},
+		{80, "90367"},
+		{100,"90365"},
+		{150,"90355"},
+	};
 
-	TBEvent TBEvent(filein,fileout);
+	TString name 			 = "raw_siwecal_" + run_list[energy] + "_" + particle + "_" + to_string(energy) + ".0GeV";
+	TString input_path = "../../data/reco/";
+
+	cout << "Input: " << name << endl; 
+
+	TBEvent TBEvent(input_path,name);
 	// TBEvent.ana_SumE();
 	// TBEvent.ana_Eff();
 	// TBEvent.ana_Energy();

--- a/cpp/reco/run.cc
+++ b/cpp/reco/run.cc
@@ -36,8 +36,8 @@ void run(int set_ene = 10, string particle = "e"){
 	// TBEvent.ana_Eff();
 	// TBEvent.ana_Energy();
 	// TBEvent.ana_adc_bcid();
-	// TBEvent.ana_quality();
-	TBEvent.ana_radius();
+	TBEvent.ana_quality();
+	// TBEvent.ana_radius();
 
 	ROOT::Math::MinimizerOptions::SetDefaultMaxFunctionCalls( 200 );
 

--- a/cpp/reco/run.cc
+++ b/cpp/reco/run.cc
@@ -6,21 +6,6 @@
 
 void run(int energy = 10, string particle = "e-"){
 
-/*
-	// TString name = particle + TString(to_string(set_ene));
-	string name = particle + "_" + to_string(set_ene);
-	cout << name << endl;
-
-
-	TString filein = "default";
-	string fileinpath = "../../data/reco/raw_siwecal_90";
-	filein = fileinpath + run_list[name] + "/full_run.root";
-
-	TString fileout = "default";
-	string fileoutpath = "rootfiles/";
-	fileout = fileoutpath + "run_90" + run_list[name] + "." + name;
-*/
-
 	std::map<int, std::string> run_list {
 		{10, "90320"},
 		{20, "90378"},

--- a/cpp/reco/src/TBEvent.cc
+++ b/cpp/reco/src/TBEvent.cc
@@ -358,8 +358,8 @@ void TBEvent::ana_quality()
 
    Long64_t nentries = fChain->GetEntriesFast();
 
-   // TFile *MyFile = new TFile("rootfiles/run_90320.e.10GeV.quality.root","RECREATE");
-   OutFile = new TFile(OutFileName + "GeV.quality.root","RECREATE");
+   TString outpath = "rootfiles/quality/";
+   OutFile = new TFile(outpath + OutFileName + "_quality.root","RECREATE");
 
    TList* hList = new TList();
    TList* hList_energy = new TList();

--- a/cpp/reco_sim/reco_sim_analysis.cc
+++ b/cpp/reco_sim/reco_sim_analysis.cc
@@ -34,8 +34,11 @@ void legend(TH1F *rh,TH1F *sh)
 	leg0->Draw("same");	
 }
 
-void readfiles(string name, TFile *f_rs[])
+void readfiles(string particle, int energy, TFile *f_rs[])
 {
+	string reco_name = particle + "." + to_string(energy);
+	string sim_name  = particle + "-." + to_string(energy);
+
 	std::map<std::string, std::string> run_list {
 		{"e.10", "320"},
 		{"e.20", "378"},
@@ -46,8 +49,8 @@ void readfiles(string name, TFile *f_rs[])
 		{"e.150", "355"},
 	};
 
-	TString reco_file = "../reco/rootfiles/quality/run_90" + run_list[name] + "." + name + "GeV.quality.root";
-	TString sim_file  = "../sim/rootfiles/ECAL.sim." + name + "GeV.quality.root";
+	TString reco_file = "../reco/rootfiles/quality/run_90" + run_list[reco_name] + "." + reco_name + "GeV.quality.root";
+	TString sim_file  = "../sim/rootfiles/ECAL.sim." + sim_name + "GeV.quality.root";
 
 	cout << "reco file: " << reco_file << endl;
 	cout << " sim file: " << sim_file << endl;
@@ -126,8 +129,8 @@ void reco_sim_analysis(string particle = "e")
 	int l_energy[nene] = {10, 20, 40, 60, 80, 100, 150};
 	for (int ie=0; ie<nene; ie++){
 		TFile *f_rs[2];
-		string name = particle + "." + to_string(l_energy[ie]);
-		readfiles(name,f_rs);
+		// string name = particle + "." + to_string(l_energy[ie]);
+		readfiles(particle,l_energy[ie],f_rs);
 		c_sum_energy->cd(ie+1);
 		slab_energy(l_energy[ie],f_rs);
 		c_nhit_slab->cd(ie+1);

--- a/cpp/reco_sim/reco_sim_analysis.cc
+++ b/cpp/reco_sim/reco_sim_analysis.cc
@@ -36,8 +36,6 @@ void legend(TH1F *rh,TH1F *sh)
 
 void readfiles(string particle, int energy, TFile *f_rs[])
 {
-	string reco_name = particle + "." + to_string(energy);
-	string sim_name  = particle + "-." + to_string(energy);
 
 	std::map<int, std::string> run_list {
 		{10, "90320"},
@@ -50,7 +48,7 @@ void readfiles(string particle, int energy, TFile *f_rs[])
 	};
 
 	TString reco_path	= "../reco/rootfiles/quality/";
-	TString sim_path	= "../sim/rootfiles/";
+	TString sim_path	= "../sim/rootfiles/quality/" ;
 	TString reco_name	= "raw_siwecal_" + run_list[energy];
 	TString sim_name  = "ECAL_QGSP_BERT_conf6"
 	

--- a/cpp/reco_sim/reco_sim_analysis.cc
+++ b/cpp/reco_sim/reco_sim_analysis.cc
@@ -50,7 +50,7 @@ void readfiles(string particle, int energy, TFile *f_rs[])
 	TString reco_path	= "../reco/rootfiles/quality/";
 	TString sim_path	= "../sim/rootfiles/quality/" ;
 	TString reco_name	= "raw_siwecal_" + run_list[energy];
-	TString sim_name  = "ECAL_QGSP_BERT_conf6"
+	TString sim_name  = "ECAL_QGSP_BERT_conf6";
 	
 	TString common_name = "_" + particle + "_" + to_string(energy) + ".0GeV_quality.root";
 
@@ -122,7 +122,7 @@ void nhit_slab(int set_ene, TFile *f_rs[])
 
 }
 
-void reco_sim_analysis(string particle = "e")
+void reco_sim_analysis(string particle = "e-")
 {
 	TFile *MyFile = new TFile("rootfiles/reco_sim_analysis.root","RECREATE");
 	TCanvas *c_sum_energy = new TCanvas("c_sum_energy","c_sum_energy",700,700);

--- a/cpp/reco_sim/reco_sim_analysis.cc
+++ b/cpp/reco_sim/reco_sim_analysis.cc
@@ -39,21 +39,28 @@ void readfiles(string particle, int energy, TFile *f_rs[])
 	string reco_name = particle + "." + to_string(energy);
 	string sim_name  = particle + "-." + to_string(energy);
 
-	std::map<std::string, std::string> run_list {
-		{"e.10", "320"},
-		{"e.20", "378"},
-		{"e.40", "375"},
-		{"e.60", "372"},
-		{"e.80", "367"},
-		{"e.100", "365"},
-		{"e.150", "355"},
+	std::map<int, std::string> run_list {
+		{10, "90320"},
+		{20, "90378"},
+		{40, "90375"},
+		{60, "90372"},
+		{80, "90367"},
+		{100,"90365"},
+		{150,"90355"},
 	};
 
-	TString reco_file = "../reco/rootfiles/quality/run_90" + run_list[reco_name] + "." + reco_name + "GeV.quality.root";
-	TString sim_file  = "../sim/rootfiles/ECAL.sim." + sim_name + "GeV.quality.root";
+	TString reco_path	= "../reco/rootfiles/quality/";
+	TString sim_path	= "../sim/rootfiles/";
+	TString reco_name	= "raw_siwecal_" + run_list[energy];
+	TString sim_name  = "ECAL_QGSP_BERT_conf6"
+	
+	TString common_name = "_" + particle + "_" + to_string(energy) + ".0GeV_quality.root";
+
+	TString reco_file = reco_path + reco_name + common_name;
+	TString sim_file  = sim_path  + sim_name  + common_name;
 
 	cout << "reco file: " << reco_file << endl;
-	cout << " sim file: " << sim_file << endl;
+	cout << " sim file: " << sim_file  << endl;
 
 	f_rs[0] = TFile::Open(reco_file);
 	f_rs[1] = TFile::Open(sim_file);

--- a/cpp/sim/include/TBEvent.hh
+++ b/cpp/sim/include/TBEvent.hh
@@ -85,7 +85,7 @@ public :
    TBranch        *b_hit_y;   //!
    TBranch        *b_hit_z;   //!
 
-   TBEvent(TString filein_s, TString fileout_s);
+   TBEvent(TString input_path, TString name);
    TBEvent(TList *f=0);
    virtual ~TBEvent();
    virtual Int_t    Cut(Long64_t entry);
@@ -102,19 +102,21 @@ public :
    virtual Bool_t   Notify();
    virtual void     Show(Long64_t entry = -1);
    TFile *OutFile;
+   TString OutFileName;
 };
 
 #endif
 
 #ifdef TBEvent_cxx
 
-TBEvent::TBEvent(TString filein_s,TString fileout_s) : fChain(0) 
+TBEvent::TBEvent(TString input_path,TString name) : fChain(0) 
 {
+   TString filein_s = input_path + name + "_build.root";
    TFile *f = new TFile(filein_s);
    TTree *tree = (TTree*)f->Get("ecal");
    //  tree->Print();
    Init(tree);
-   OutFile = new TFile(fileout_s,"RECREATE");
+   OutFileName = name;
 }
 
 TBEvent::TBEvent(TList *f) : fChain(0) 

--- a/cpp/sim/it_ene.sh
+++ b/cpp/sim/it_ene.sh
@@ -4,6 +4,6 @@ for particle in e- mu-
 do
     for energy in 10 20 40 60 80 100 150
     do
-        root -l -q run_sim.cc\(${energy},${particle}\)
+        root -l -q run_sim.cc\(${energy},\"${particle}\"\)
     done
 done

--- a/cpp/sim/it_ene.sh
+++ b/cpp/sim/it_ene.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-for energy in 10 20 40 60 80 100 150
+for particle in e- mu-
 do
-    root -l -q run_sim.cc\(${energy}\)
+    for energy in 10 20 40 60 80 100 150
+    do
+        root -l -q run_sim.cc\(${energy},${particle}\)
+    done
 done

--- a/cpp/sim/run_sim.cc
+++ b/cpp/sim/run_sim.cc
@@ -7,7 +7,7 @@
 void run_sim(int energy = 10, string particle = "e-"){
 
 	TString input_path = "../../data/sim/";
-	TString sim_name   = "ECAL_QGSP_BERT_conf6_" + particle + "_" + to_string(energy) + ".0GeV"
+	TString sim_name   = "ECAL_QGSP_BERT_conf6_" + particle + "_" + to_string(energy) + ".0GeV";
 
 	cout << "Input: " << input_path << endl; 
 

--- a/cpp/sim/run_sim.cc
+++ b/cpp/sim/run_sim.cc
@@ -4,30 +4,16 @@
 
 #include "src/TBEvent.cc"
 
-void run_sim(int set_ene = 10, string particle = "e-"){
+void run_sim(int energy = 10, string particle = "e-"){
 
-	// TString name = particle + TString(to_string(set_ene));
-	string name = particle + "." + to_string(set_ene);
-	cout << name << endl;
+	TString input_path = "../../data/sim/";
+	TString sim_name   = "ECAL_QGSP_BERT_conf6_" + particle + "_" + to_string(energy) + ".0GeV"
 
-	TString filein = "default";
-	string fileinpath = "../../data/sim/";
-	filein = fileinpath + "/ECAL_QGSP_BERT_conf6_" + particle + "_" + to_string(set_ene) + ".0GeV_build.root";
+	cout << "Input: " << input_path << endl; 
 
-	TString fileout = "default";
-	string fileoutpath = "rootfiles/";
-	fileout = fileoutpath + "ECAL.sim." + name + "GeV.quality.root";
-
-	cout << "Input: " << filein << endl; 
-
-	TBEvent TBEvent(filein,fileout);
-	// TBEvent.ana_SumE();
-	// TBEvent.ana_Eff();
-	// TBEvent.ana_Energy();
-	// TBEvent.ana_adc_bcid();
+	TBEvent TBEvent(input_path,sim_name);
 	TBEvent.ana_quality();
 
-	cout << "Output: " << fileout << endl; 
 	ROOT::Math::MinimizerOptions::SetDefaultMaxFunctionCalls( 200 );
 
 	gSystem->Exit(0);

--- a/cpp/sim/run_sim.cc
+++ b/cpp/sim/run_sim.cc
@@ -4,19 +4,19 @@
 
 #include "src/TBEvent.cc"
 
-void run_sim(int set_ene = 10, string particle = "sim.e"){
+void run_sim(int set_ene = 10, string particle = "e-"){
 
 	// TString name = particle + TString(to_string(set_ene));
 	string name = particle + "." + to_string(set_ene);
 	cout << name << endl;
 
 	TString filein = "default";
-	string fileinpath = "../../data/sim/e" + to_string(set_ene) + "GeV/";
-	filein = fileinpath + "/ECAL_QGSP_BERT_conf5_e-_" + to_string(set_ene) + ".0GeV.root";
+	string fileinpath = "../../data/sim/";
+	filein = fileinpath + "/ECAL_QGSP_BERT_conf6_" + particle + "_" + to_string(set_ene) + ".0GeV_build.root";
 
 	TString fileout = "default";
 	string fileoutpath = "rootfiles/";
-	fileout = fileoutpath + "ECAL." + name + "GeV.quality.root";
+	fileout = fileoutpath + "ECAL.sim." + name + "GeV.quality.root";
 
 	cout << "Input: " << filein << endl; 
 

--- a/cpp/sim/src/TBEvent.cc
+++ b/cpp/sim/src/TBEvent.cc
@@ -27,6 +27,9 @@ void TBEvent::ana_quality()
 
    Long64_t nentries = fChain->GetEntriesFast();
 
+   TString outpath = "rootfiles/quality/";
+   OutFile = new TFile(outpath + OutFileName + "_quality.root","RECREATE");
+
    TList* hList = new TList();
    TList* hList_energy = new TList();
    TH1F * h_sum_energy = new TH1F("h_sum_energy","; sum_energy; Entries",500,0,1.5E4);

--- a/tools/download_build_files.sh
+++ b/tools/download_build_files.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+runIDs=( 20 78 75 72 67 65 55 )
+energies=( 10 20 40 60 80 100 150 )
+
+for i in "${!energies[@]}"
+do
+  scp calice@pc-calice:/home/calice/TB2022-06/SiWECAL-TB-monitoring/data/raw_siwecal_903${runIDs[i]}/full_run.root \
+  raw_siwecal_903${runIDs[i]}_e-_${energies[i]}.0GeV_build.root
+done


### PR DESCRIPTION
## File Names
File names are now store as following:
### Reconstructed Data
For reconstructed data, prefix will be
```
raw_siwecal_${runID}_${particle}_${energy}.0GeV
```
Suffix are defined as:
 - **build** (Input file): `_build.root`
 - **quality**              : `_quality.root`

### Simulation
For simulation, prefix will be (conf6 can be changed)
```
ECAL_QGSP_BERT_conf6_${particle}_${energy}.0GeV
```
Suffix are defined as:
 - **build** (Input file): `_build.root`
 - **quality**              : `_quality.root`